### PR TITLE
Accessibility fixes, template hygiene, and regenerated docs output

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/acp2.html
+++ b/docs/acp2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -418,8 +417,8 @@
                 <div id="question-wrapper" class="padding-top" data-question-file="acp2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/acp3.html
+++ b/docs/acp3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/acp4.html
+++ b/docs/acp4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -429,8 +428,8 @@
                 <div id="question-wrapper" class="padding-top" data-question-file="acp4_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/acp5.html
+++ b/docs/acp5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -578,9 +577,9 @@
                             </div>
 
                             <div class="flashcard-row">
-                                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                             </div>
                             <div class="flashcard-row padding-top">
                                 <button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/docs/adj2.html
+++ b/docs/adj2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -171,16 +170,16 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs four-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#god" aria-controls="Good" role="tab" data-toggle="tab">God</a>
+                                    <a href="#god" aria-controls="god" role="tab" data-toggle="tab">God</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#halig" aria-controls="Halig" role="tab" data-toggle="tab">Halig</a>
+                                    <a href="#halig" aria-controls="halig" role="tab" data-toggle="tab">Halig</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#heah" aria-controls="Heah" role="tab" data-toggle="tab">Heah</a>
+                                    <a href="#heah" aria-controls="heah" role="tab" data-toggle="tab">Heah</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#wise" aria-controls="wis" role="tab" data-toggle="tab">Wis</a>
+                                    <a href="#wis" aria-controls="wis" role="tab" data-toggle="tab">Wis</a>
                                 </li>
                             </ul>
                             <!-- Tab panes -->
@@ -326,7 +325,7 @@
                                         </tr>
                                     </table>
                                 </div>
-                                <div role="tabpanel" class="text-center tab-pane" id="wise">
+                                <div role="tabpanel" class="text-center tab-pane" id="wis">
                                     <table class="tabbed-table table-striped inline-block five-col-table table-hide">
                                         <tr>
                                             <th></th>
@@ -444,17 +443,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="adj2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/adj3.html
+++ b/docs/adj3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -225,16 +224,16 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs four-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#god" aria-controls="Good" role="tab" data-toggle="tab">God</a>
+                                    <a href="#god" aria-controls="god" role="tab" data-toggle="tab">God</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#halig" aria-controls="Halig" role="tab" data-toggle="tab">Halig</a>
+                                    <a href="#halig" aria-controls="halig" role="tab" data-toggle="tab">Halig</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#heah" aria-controls="Heah" role="tab" data-toggle="tab">Heah</a>
+                                    <a href="#heah" aria-controls="heah" role="tab" data-toggle="tab">Heah</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#wilde" aria-controls="wild" role="tab" data-toggle="tab">Wilde</a>
+                                    <a href="#wilde" aria-controls="wilde" role="tab" data-toggle="tab">Wilde</a>
                                 </li>
                             </ul>
                             <!-- Tab panes -->
@@ -504,9 +503,9 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an
                         input
                         selected.</sub>
@@ -514,8 +513,8 @@
                 <div id="question-wrapper" data-question-file="adj3_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/adj4.html
+++ b/docs/adj4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -393,9 +392,9 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an
                         input
                         selected.</sub>
@@ -403,8 +402,8 @@
                 <div id="question-wrapper" data-question-file="adj4_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/adj5.html
+++ b/docs/adj5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -604,9 +603,9 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs">
                     <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
@@ -614,8 +613,8 @@
                 <div id="question-wrapper" data-question-file="adj5_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>
@@ -670,9 +669,9 @@
                             </div>
 
                             <div class="flashcard-row">
-                                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                             </div>
                             <div class="flashcard-row padding-top">
                                 <button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/docs/adjectives.html
+++ b/docs/adjectives.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/advanced.html
+++ b/docs/advanced.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/advanced2.html
+++ b/docs/advanced2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -336,10 +335,10 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs five-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#sculan" aria-controls="shulan" role="tab" data-toggle="tab">Sculan</a>
+                                    <a href="#sculan" aria-controls="sculan" role="tab" data-toggle="tab">Sculan</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#magan" aria-controls="mayan" role="tab" data-toggle="tab">Magan</a>
+                                    <a href="#magan" aria-controls="magan" role="tab" data-toggle="tab">Magan</a>
                                 </li>
                                 <li role="presentation">
                                     <a href="#motan" aria-controls="motan" role="tab" data-toggle="tab">Motan</a>
@@ -564,17 +563,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="advanced2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/advanced3.html
+++ b/docs/advanced3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -252,17 +251,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="advanced3_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/advanced4.html
+++ b/docs/advanced4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -744,17 +743,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="advanced4_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/advanced5.html
+++ b/docs/advanced5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/advanced6.html
+++ b/docs/advanced6.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -348,17 +347,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="advanced6_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/adverbs.html
+++ b/docs/adverbs.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/advpronunciationguide.html
+++ b/docs/advpronunciationguide.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/cases.html
+++ b/docs/cases.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/cases2.html
+++ b/docs/cases2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -420,17 +419,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <small>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</small>
                 </p>
                 <div id="question-wrapper" data-question-file="cases2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/cases3.html
+++ b/docs/cases3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -395,17 +394,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="cases3_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/cases4.html
+++ b/docs/cases4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -220,17 +219,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="cases4_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/cases5.html
+++ b/docs/cases5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -764,9 +763,9 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an
                         input
                         selected.</sub>
@@ -774,8 +773,8 @@
                 <div id="question-wrapper" data-question-file="cases5_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/courseindex.html
+++ b/docs/courseindex.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -70,16 +69,15 @@
     <main id="mainwrapper" class="container">
         <section class="row">
             <div class="col-12">
-                <h1 class="text-center remove-margin">Course Index</h2>
-                    <p class="text-center"> Click an orange title to begin the module, or choose a specific topic
-                        below.</p>
-                    <ul class="course-index">
-                        <a href="oestart.html">
-                            <li class="listtitle">A Quick Note on the Alphabet</li>
-                        </a><br>
-                        <a href="cases.html">
-                            <li class="listtitle">Cases</li>
-                        </a>
+                <h1 class="text-center remove-margin">Course Index</h1>
+                <p class="text-center"> Click an orange title to begin the module, or choose a specific topic
+                    below.</p>
+                <ul class="course-index">
+                    <li class="listtitle">
+                        <a href="oestart.html">A Quick Note on the Alphabet</a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="cases.html">Cases</a>
                         <ul class="module">
                             <li>
                                 <a href="cases2.html">Nominative and Genitive Strong Masculine Nouns</a>
@@ -94,10 +92,9 @@
                                 <a href="cases5.html">Strong Masculine Nouns Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="weakverbs.html">
-                            <li class="listtitle">Weak Verbs</li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="weakverbs.html">Weak Verbs</a>
                         <ul class="module">
                             <li>
                                 <a href="wv2.html">Brief Intro to Personal Pronouns</a>
@@ -115,10 +112,9 @@
                                 <a href="wv6.html">Weak Verbs Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="nafnouns.html">
-                            <li class="listtitle">Strong Neuter and Feminine Nouns</li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="nafnouns.html">Strong Neuter and Feminine Nouns</a>
                         <ul class="module">
                             <li>
                                 <a href="naf2.html">Strong Neuter Nouns</a>
@@ -139,10 +135,9 @@
                                 <a href="naf7.html">Strong Nouns Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="pronouns.html">
-                            <li class="listtitle">Pronouns</li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="pronouns.html">Pronouns</a>
                         <ul class="module">
                             <li>
                                 <a href="pro2.html">Personal Pronouns</a>
@@ -160,10 +155,9 @@
                                 <a href="pro6.html">Pronouns Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="irregular.html">
-                            <li class="listtitle">Irregular Verbs</li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="irregular.html">Irregular Verbs</a>
                         <ul class="module">
                             <li>
                                 <a href="irgv2.html">Beon and Wesan</a>
@@ -178,10 +172,9 @@
                                 <a href="irgv5.html">Irregular Verbs Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="adjectives.html">
-                            <li class="listtitle">Adjectives</li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="adjectives.html">Adjectives</a>
                         <ul class="module">
                             <li>
                                 <a href="adj2.html">Weak Adjectives</a>
@@ -196,10 +189,9 @@
                                 <a href="adj5.html">Adjectives Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="weakandminor.html">
-                            <li class="listtitle">Weak Nouns and Minor Nouns</li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="weakandminor.html">Weak Nouns and Minor Nouns</a>
                         <ul class="module">
                             <li>
                                 <a href="wam2.html">Weak Nouns</a>
@@ -214,10 +206,9 @@
                                 <a href="wam5.html">Nouns Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="adverbs.html">
-                            <li class="listtitle">Adverbs, Conjunctions, and Prepositions</li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="adverbs.html">Adverbs, Conjunctions, and Prepositions</a>
                         <ul class="module">
                             <li>
                                 <a href="acp2.html">Adverbs</a>
@@ -232,11 +223,10 @@
                                 <a href="acp5.html">Adverbs, Conjunctions, and Prepositions Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="moods.html">
-                            <li class="listtitle">
-                                Moods</li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="moods.html">Moods</a>
+
                         <ul class="module">
                             <li>
                                 <a href="moods2.html">Imperative</a>
@@ -248,10 +238,9 @@
                                 <a href="moods4.html">Moods Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="advanced.html">
-                            <li class="listtitle">Additional Verb Forms</li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="advanced.html">Additional Verb Forms</a>
                         <ul class="module">
 
                             <li>
@@ -270,13 +259,9 @@
                                 <a href="advanced6.html">Additional Verb Forms Overview</a>
                             </li>
                         </ul>
-
-                        <br>
-                        <a href="strongverbs.html">
-                            <li class="listtitle">
-                                Strong Verbs
-                            </li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="strongverbs.html">Strong Verbs</a>
                         <ul class="module">
                             <li>
                                 <a href="sv1_5.html">Strong Verbs Pronunciation Guide</a>
@@ -306,11 +291,9 @@
                                 <a href="sv9.html">Strong Verb Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="negations.html">
-                            <li class="listtitle">
-                                Negations </li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="negations.html">Negations</a>
                         <ul class="module">
                             <li>
                                 <a href="neg2.html">Negated Verbs</a>
@@ -322,11 +305,9 @@
                                 <a href="neg4.html">Negations Overview</a>
                             </li>
                         </ul>
-                        <br>
-                        <a href="syntax.html">
-                            <li class="listtitle">
-                                Basic Syntax </li>
-                        </a>
+                    </li>
+                    <li class="listtitle">
+                        <a href="syntax.html">Basic Syntax</a>
                         <ul class="module">
                             <li>
                                 <a href="syntax2.html">Word Order</a>
@@ -341,6 +322,8 @@
                                 <a href="syntax5.html">Syntax Overview</a>
                             </li>
                         </ul>
+                    </li>
+                </ul>
             </div>
         </section>
     </main>

--- a/docs/facsimile_dicts_cato.html
+++ b/docs/facsimile_dicts_cato.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/history.html
+++ b/docs/history.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/intro_aelfric_genesis.html
+++ b/docs/intro_aelfric_genesis.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/intro_aelfric_preface.html
+++ b/docs/intro_aelfric_preface.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/intro_as_755.html
+++ b/docs/intro_as_755.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/intro_as_888.html
+++ b/docs/intro_as_888.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/intro_balds_cold.html
+++ b/docs/intro_balds_cold.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/intro_dicts_cato.html
+++ b/docs/intro_dicts_cato.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/intro_pater_noster.html
+++ b/docs/intro_pater_noster.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/intro_sigewulfi.html
+++ b/docs/intro_sigewulfi.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/irgv2.html
+++ b/docs/irgv2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -249,17 +248,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="irgv2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/irgv3.html
+++ b/docs/irgv3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -318,17 +317,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="irgv3_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/irgv4.html
+++ b/docs/irgv4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -227,17 +226,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="irgv4_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/irgv5.html
+++ b/docs/irgv5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -625,17 +624,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="irgv5_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/irregular.html
+++ b/docs/irregular.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/license.html
+++ b/docs/license.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -71,10 +70,10 @@
         <section class="row">
             <div class="col-12-sm">
                 <h1 class="remove-margin">Licensing and Copyright Information</h1><br>
-                <p>The project code is licensed under the MIT License. Copyright © 2021 - Victoria Koivisto-Kokko. All code is available publicly on <a class="darkorange-text" target="_blank" href="https://github.com/vkkokko/oldenglishonline">Github</a>.</p>
+                <p>The project code is licensed under the MIT License. Copyright © 2021 - Victoria Koivisto-Kokko. All code is available publicly on <a class="darkorange-text" target="_blank" rel="noopener noreferrer" href="https://github.com/vkkokko/oldenglishonline">Github</a>.</p>
                 <p>The project content (i.e. the textual content, quizzes, graphical organisers) is licensed under Creative Commons Attribution + Share Alike (BY-SA).</p>
                 <p>This website uses Google Analytics to collect anonymised data regarding the site's usage.</p>
-                <p>This website uses material from the Wikipedia article <a class="darkorange-text" target="_blank" href="https://commons.wikimedia.org/wiki/General_phonetics">General Phonetics</a>, which is released under the <a class="darkorange-text" target="_blank" href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-Share-Alike License 3.0</a>.
+                <p>This website uses material from the Wikipedia article <a class="darkorange-text" target="_blank" rel="noopener noreferrer" href="https://commons.wikimedia.org/wiki/General_phonetics">General Phonetics</a>, which is released under the <a class="darkorange-text" target="_blank" rel="noopener noreferrer" href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-Share-Alike License 3.0</a>.
                 </p>
             </div>
         </section>

--- a/docs/moods.html
+++ b/docs/moods.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/moods2.html
+++ b/docs/moods2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -448,17 +447,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="moods2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/moods3.html
+++ b/docs/moods3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -733,17 +732,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="moods3_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/moods4.html
+++ b/docs/moods4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/naf2.html
+++ b/docs/naf2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -215,16 +214,16 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs five-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#scip" aria-controls="ship" role="tab" data-toggle="tab">Scip</a>
+                                    <a href="#scip" aria-controls="scip" role="tab" data-toggle="tab">Scip</a>
                                 </li>
                                 <li role="presentation">
                                     <a href="#word" aria-controls="word" role="tab" data-toggle="tab">Word</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#bearn" aria-controls="barn" role="tab" data-toggle="tab">Bearn</a>
+                                    <a href="#bearn" aria-controls="bearn" role="tab" data-toggle="tab">Bearn</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#wif" aria-controls="wife" role="tab" data-toggle="tab">Wif</a>
+                                    <a href="#wif" aria-controls="wif" role="tab" data-toggle="tab">Wif</a>
                                 </li>
                                 <li role="presentation">
                                     <a href="#god" aria-controls="god" role="tab" data-toggle="tab">God</a>
@@ -562,17 +561,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="naf2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/naf3.html
+++ b/docs/naf3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -216,17 +215,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="naf3_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/naf4.html
+++ b/docs/naf4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -223,19 +222,19 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs five-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#cwen" aria-controls="queen" role="tab" data-toggle="tab">Cwen</a>
+                                    <a href="#cwen" aria-controls="cwen" role="tab" data-toggle="tab">Cwen</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#giefu" aria-controls="yifu" role="tab" data-toggle="tab">Giefu</a>
+                                    <a href="#giefu" aria-controls="giefu" role="tab" data-toggle="tab">Giefu</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#lufu" aria-controls="love" role="tab" data-toggle="tab">Lufu</a>
+                                    <a href="#lufu" aria-controls="lufu" role="tab" data-toggle="tab">Lufu</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#theod" aria-controls="theod" role="tab" data-toggle="tab">Ceaster</a>
+                                    <a href="#ceaster" aria-controls="ceaster" role="tab" data-toggle="tab">Ceaster</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#ides" aria-controls="eedes" role="tab" data-toggle="tab">Ides</a>
+                                    <a href="#ides" aria-controls="ides" role="tab" data-toggle="tab">Ides</a>
                                 </li>
                             </ul>
                             <!-- Tab panes -->
@@ -399,7 +398,7 @@
                                     </table>
                                 </div>
 
-                                <div role="tabpanel" class="text-center tab-pane" id="theod">
+                                <div role="tabpanel" class="text-center tab-pane" id="ceaster">
                                     <table class="tabbed-table table-striped inline-block five-col-table table-hide">
                                         <tr>
                                             <td colspan="5">
@@ -547,17 +546,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="naf4_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/naf5.html
+++ b/docs/naf5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -221,17 +220,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="naf5_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/naf6.html
+++ b/docs/naf6.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -821,17 +820,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="naf6_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/naf7.html
+++ b/docs/naf7.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -294,13 +293,13 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs four-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#class1a" aria-controls="class 1" role="tab" data-toggle="tab">Cyning</a>
+                                    <a href="#class1a" aria-controls="class1a" role="tab" data-toggle="tab">Cyning</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#class1b" aria-controls="class 1b" role="tab" data-toggle="tab">Scip</a>
+                                    <a href="#class1b" aria-controls="class1b" role="tab" data-toggle="tab">Scip</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#class1c" aria-controls="class 1c" role="tab" data-toggle="tab">Cwen</a>
+                                    <a href="#class1c" aria-controls="class1c" role="tab" data-toggle="tab">Cwen</a>
                                 </li>
                             </ul>
                             <!-- Tab panes -->
@@ -499,17 +498,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="naf7_answers.json" data-additional-questions="naf8_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>
@@ -562,9 +561,9 @@
                             </div>
 
                             <div class="flashcard-row">
-                                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                             </div>
                             <div class="flashcard-row padding-top">
                                 <button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/docs/nafnouns.html
+++ b/docs/nafnouns.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/neg2.html
+++ b/docs/neg2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -401,17 +400,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="neg2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/neg3.html
+++ b/docs/neg3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/neg4.html
+++ b/docs/neg4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/negations.html
+++ b/docs/negations.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/oestart.html
+++ b/docs/oestart.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/patchnotes.html
+++ b/docs/patchnotes.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/pro2.html
+++ b/docs/pro2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -351,17 +350,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="pro2_answers.json" data-additional-questions="pro2_5_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/pro3.html
+++ b/docs/pro3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -166,17 +165,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="pro3_answers.json" data-additional-questions="pro3_5_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/pro4.html
+++ b/docs/pro4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -429,17 +428,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="pro4_answers.json" data-additional-questions="pro4_5_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/pro5.html
+++ b/docs/pro5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/pro6.html
+++ b/docs/pro6.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -530,17 +529,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="pro6_answers.json" data-table-file="table_test.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/pronouns.html
+++ b/docs/pronouns.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -164,8 +164,8 @@
 			loadQuestionsInto($container, filename);
 
 			$('small').replaceWith('<small>In the textboxes below, fill out the fully declined version of the word in brackets.</small>');
-			$('#table-submit').replaceWith('<button class="solid-button button" id="submit">Check</button>');
-			$('#table-try-again').replaceWith('<button class="solid-button button hidden" id="again">Try Again?</button>');
+			$('#table-submit').replaceWith('<button type="submit" class="solid-button button" id="submit">Check</button>');
+			$('#table-try-again').replaceWith('<button type="button" class="solid-button button hidden" id="again">Try Again?</button>');
 		});
 
 	});

--- a/docs/scripts/scraps.js
+++ b/docs/scripts/scraps.js
@@ -11,8 +11,8 @@
 //     loadQuestionsInto($container, filename);
 
 //     $('small').replaceWith('<small>In the textboxes below, fill out the fully declined version of the word in brackets.</small>');
-//     $('#table-submit').replaceWith('<button class="solid-button button" id="submit">Check</button>');
-//     $('#table-try-again').replaceWith('<button class="solid-button button hidden" id="again">Try Again?</button>');
+//     $('#table-submit').replaceWith('<button type="submit" class="solid-button button" id="submit">Check</button>');
+//     $('#table-try-again').replaceWith('<button type="button" class="solid-button button hidden" id="again">Try Again?</button>');
 // });
 
 // //This is the code which replaces the fill-in-the-blank with the table quiz

--- a/docs/strongverbs.html
+++ b/docs/strongverbs.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/styles/oeccss.css
+++ b/docs/styles/oeccss.css
@@ -1063,8 +1063,13 @@ table th {
 .bc-icons-2 .breadcrumb-item + .breadcrumb-item::before {
 	content: none;
 }
+
 .bc-icons-2 .breadcrumb-item.active {
 	color: rgb(200, 100, 50);
+}
+
+.bc-icons-2 .breadcrumb .fa-angle-double-right {
+  	margin: 0 4px;
 }
 
 /* Module index*/
@@ -1075,10 +1080,16 @@ table th {
 
 li.listtitle {
 	list-style-type: none;
+	margin-bottom: 24px;
+}
+
+li.listtitle > a {
 	color: rgb(200, 100, 50);
+	font-family: Georgia, Times, "Times New Roman", serif;
 	font-size: 24px;
 	font-weight: bold;
 	text-decoration: underline;
+	display: block;
 }
 
 li.inactive {
@@ -1095,8 +1106,15 @@ ul.module li {
 	padding-top: 5px;
 }
 
-ul.module a {
+ul.module a,
+ul.module a >:visited {
 	color: black;
+	text-decoration: none;
+}
+
+ul.module a:hover,
+ul.module a:focus {
+	text-decoration: underline;
 }
 
 .user-input {

--- a/docs/sv1_5.html
+++ b/docs/sv1_5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/sv2.html
+++ b/docs/sv2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -583,17 +582,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="sv2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/sv3.html
+++ b/docs/sv3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -225,7 +224,7 @@
                                     <a href="#beodan" aria-controls="beodan" role="tab" data-toggle="tab">Beodan</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#leogan" aria-controls="leoyan" role="tab" data-toggle="tab">Leogan</a>
+                                    <a href="#leogan" aria-controls="leogan" role="tab" data-toggle="tab">Leogan</a>
                                 </li>
                                 <li role="presentation">
                                     <a href="#brucan" aria-controls="brucan" role="tab" data-toggle="tab">Brucan</a>
@@ -531,17 +530,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="sv3_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/sv4.html
+++ b/docs/sv4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -272,7 +271,7 @@
                                     <a href="#weorpan" aria-controls="weorpan" role="tab" data-toggle="tab">Weorpan</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#gieldan" aria-controls="yieldan" role="tab" data-toggle="tab">Gieldan</a>
+                                    <a href="#gieldan" aria-controls="gieldan" role="tab" data-toggle="tab">Gieldan</a>
                                 </li>
                             </ul>
                             <!-- Tab panes -->
@@ -573,17 +572,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="sv4_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/sv5.html
+++ b/docs/sv5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -466,17 +465,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="sv5_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/sv6.html
+++ b/docs/sv6.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -526,17 +525,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="sv6_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/sv7.html
+++ b/docs/sv7.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -224,10 +223,10 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs five-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#wascan" aria-controls="washan" role="tab" data-toggle="tab">Wascan</a>
+                                    <a href="#wascan" aria-controls="wascan" role="tab" data-toggle="tab">Wascan</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#dragan" aria-controls="drayan" role="tab" data-toggle="tab">Dragan</a>
+                                    <a href="#dragan" aria-controls="dragan" role="tab" data-toggle="tab">Dragan</a>
                                 </li>
                                 <li role="presentation">
                                     <a href="#slean" aria-controls="slean" role="tab" data-toggle="tab">Slean</a>
@@ -560,17 +559,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="sv7_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/sv8.html
+++ b/docs/sv8.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -231,7 +230,7 @@
                                     <a href="#hatan" aria-controls="hatan" role="tab" data-toggle="tab">Hatan</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#raedan" aria-controls="raedan" role="tab" data-toggle="tab">Blawan</a>
+                                    <a href="#blawan" aria-controls="blawan" role="tab" data-toggle="tab">Blawan</a>
                                 </li>
                                 <li role="presentation">
                                     <a href="#hleapan" aria-controls="hleapan" role="tab" data-toggle="tab">Hleapan</a>
@@ -540,17 +539,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="sv8_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/sv9.html
+++ b/docs/sv9.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -297,25 +296,25 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs five-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#i" aria-controls="class one" role="tab" data-toggle="tab">I</a>
+                                    <a href="#i" aria-controls="i" role="tab" data-toggle="tab">I</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#ii" aria-controls="class two" role="tab" data-toggle="tab">II</a>
+                                    <a href="#ii" aria-controls="ii" role="tab" data-toggle="tab">II</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#iii" aria-controls="class three" role="tab" data-toggle="tab">III</a>
+                                    <a href="#iii" aria-controls="iii" role="tab" data-toggle="tab">III</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#iv" aria-controls="class four" role="tab" data-toggle="tab">IV</a>
+                                    <a href="#iv" aria-controls="iv" role="tab" data-toggle="tab">IV</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#v" aria-controls="class five" role="tab" data-toggle="tab">V</a>
+                                    <a href="#v" aria-controls="v" role="tab" data-toggle="tab">V</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#vi" aria-controls="class six" role="tab" data-toggle="tab">VI</a>
+                                    <a href="#vi" aria-controls="vi" role="tab" data-toggle="tab">VI</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#vii" aria-controls="class seven" role="tab" data-toggle="tab">VII</a>
+                                    <a href="#vii" aria-controls="vii" role="tab" data-toggle="tab">VII</a>
                                 </li>
                             </ul>
                             <!-- Tab panes -->
@@ -694,17 +693,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="sv9_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>
@@ -753,9 +752,9 @@
                             </div>
 
                             <div class="flashcard-row">
-                                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                             </div>
                             <div class="flashcard-row small-padding-top">
                                 <button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/docs/syntax.html
+++ b/docs/syntax.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/syntax2.html
+++ b/docs/syntax2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/syntax3.html
+++ b/docs/syntax3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/syntax4.html
+++ b/docs/syntax4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/syntax5.html
+++ b/docs/syntax5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/template.html
+++ b/docs/template.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/test.html
+++ b/docs/test.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -85,9 +84,9 @@
             </div>
             <form name="test-form" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>

--- a/docs/text_aelfric_genesis.html
+++ b/docs/text_aelfric_genesis.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/text_aelfric_preface.html
+++ b/docs/text_aelfric_preface.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/text_as_755.html
+++ b/docs/text_as_755.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/text_as_888.html
+++ b/docs/text_as_888.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/text_balds_cold.html
+++ b/docs/text_balds_cold.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/text_dicts_cato.html
+++ b/docs/text_dicts_cato.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/text_harley_snake.html
+++ b/docs/text_harley_snake.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/text_pater_noster.html
+++ b/docs/text_pater_noster.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/text_sigewulfi.html
+++ b/docs/text_sigewulfi.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/textselect.html
+++ b/docs/textselect.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/wam2.html
+++ b/docs/wam2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -143,10 +142,10 @@
                                     <a href="#hunta" aria-controls="hunta" role="tab" data-toggle="tab">Hunta</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#eage" aria-controls="eye" role="tab" data-toggle="tab">Eage</a>
+                                    <a href="#eage" aria-controls="eage" role="tab" data-toggle="tab">Eage</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#tunge" aria-controls="tongue" role="tab" data-toggle="tab">Tunge</a>
+                                    <a href="#tunge" aria-controls="tunge" role="tab" data-toggle="tab">Tunge</a>
                                 </li>
                             </ul>
                             <!-- Tab panes -->
@@ -346,9 +345,9 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs">
                     <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
@@ -356,8 +355,8 @@
                 <div id="question-wrapper" data-question-file="wam2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/wam3.html
+++ b/docs/wam3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -314,7 +313,7 @@
                                     <a href="#cealf" aria-controls="cealf" role="tab" data-toggle="tab">Cealf</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#aeg" aria-controls="ay" role="tab" data-toggle="tab">&AElig;g</a>
+                                    <a href="#aeg" aria-controls="aeg" role="tab" data-toggle="tab">&AElig;g</a>
                                 </li>
                                 <li role="presentation">
                                     <a href="#lamb" aria-controls="lamb" role="tab" data-toggle="tab">Lamb</a>
@@ -615,7 +614,7 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs five-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#faeder" aria-controls="fader" role="tab" data-toggle="tab">Fæder</a>
+                                    <a href="#faeder" aria-controls="faeder" role="tab" data-toggle="tab">Fæder</a>
                                 </li>
                                 <li role="presentation">
                                     <a href="#modor" aria-controls="modor" role="tab" data-toggle="tab">Modor</a>
@@ -940,9 +939,9 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs">
                     <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
@@ -950,8 +949,8 @@
                 <div id="question-wrapper" data-question-file="wam3_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/wam4.html
+++ b/docs/wam4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -436,7 +435,7 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs three-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#mann" aria-controls="man" role="tab" data-toggle="tab">Mann</a>
+                                    <a href="#mann" aria-controls="mann" role="tab" data-toggle="tab">Mann</a>
                                 </li>
                                 <li role="presentation">
                                     <a href="#boc" aria-controls="boc" role="tab" data-toggle="tab">Boc</a>
@@ -588,9 +587,9 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs">
                     <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
@@ -598,8 +597,8 @@
                 <div id="question-wrapper" data-question-file="wam4_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/wam5.html
+++ b/docs/wam5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -910,17 +909,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="wam5_answers.json" data-additional-questions="wam6_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>
@@ -969,9 +968,9 @@
                             </div>
 
                             <div class="flashcard-row">
-                                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                             </div>
                             <div class="flashcard-row padding-top">
                                 <button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/docs/weakandminor.html
+++ b/docs/weakandminor.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/weakverbs.html
+++ b/docs/weakverbs.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/wip.html
+++ b/docs/wip.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/docs/wv2.html
+++ b/docs/wv2.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -240,17 +239,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="wv2_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/wv3.html
+++ b/docs/wv3.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -704,17 +703,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="wv3_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/wv4.html
+++ b/docs/wv4.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -624,17 +623,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="wv4_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/wv5.html
+++ b/docs/wv5.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -469,9 +468,9 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an
                         input
                         selected.</sub>
@@ -479,8 +478,8 @@
                 <div id="question-wrapper" data-question-file="wv5_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>

--- a/docs/wv6.html
+++ b/docs/wv6.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="english">
-    <meta http-equiv="content-type" content="text/html">
     <meta name="author" content="Victoria Koivisto-Kokko">
     <meta name="designer" content="Victoria Koivisto-Kokko">
     <meta name="publisher" content="Victoria Koivisto-Kokko">
@@ -690,16 +689,16 @@
                             <!-- Nav tabs -->
                             <ul class="nav tabs four-tabs nav-justified" role="tablist">
                                 <li role="presentation" class="active">
-                                    <a href="#class1a" aria-controls="class 1" role="tab" data-toggle="tab">Class I(a)</a>
+                                    <a href="#class1a" aria-controls="class1a" role="tab" data-toggle="tab">Class I(a)</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#class1b" aria-controls="class 1b" role="tab" data-toggle="tab">Class I(b)</a>
+                                    <a href="#class1b" aria-controls="class1b" role="tab" data-toggle="tab">Class I(b)</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#class1c" aria-controls="class 1c" role="tab" data-toggle="tab">Class I(c)</a>
+                                    <a href="#class1c" aria-controls="class1c" role="tab" data-toggle="tab">Class I(c)</a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="#class2a" aria-controls="class 2" role="tab" data-toggle="tab">Class II</a>
+                                    <a href="#class2a" aria-controls="class2a" role="tab" data-toggle="tab">Class II</a>
                                 </li>
                             </ul>
                             <!-- Tab panes -->
@@ -1022,17 +1021,17 @@
             </div>
             <form name="form1" autocomplete="OFF">
                 <p>
-                    <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                    <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                    <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                    <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                    <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                    <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                     <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                         selected.</sub>
                 </p>
                 <div id="question-wrapper" data-question-file="wv6_answers.json">
                 </div>
                 <div class="form-group">
-                    <button class="solid-button button" id="submit">Check</button>
-                    <button class="solid-button button hidden" id="again">Try Again?</button>
+                    <button type="submit" class="solid-button button" id="submit">Check</button>
+                    <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
                 </div>
             </form>
         </section>
@@ -1082,9 +1081,9 @@
                             </div>
 
                             <div class="flashcard-row">
-                                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                             </div>
                             <div class="flashcard-row small-padding-top">
                                 <button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/src/pages/acp2.ejs
+++ b/src/pages/acp2.ejs
@@ -352,8 +352,8 @@
 			<div id="question-wrapper" class="padding-top" data-question-file="acp2_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/acp4.ejs
+++ b/src/pages/acp4.ejs
@@ -363,8 +363,8 @@
 			<div id="question-wrapper" class="padding-top" data-question-file="acp4_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/acp5.ejs
+++ b/src/pages/acp5.ejs
@@ -511,9 +511,9 @@
 						</div>
 						
 						<div class="flashcard-row">
-							<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-							<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-							<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+							<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+							<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+							<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 							</div>
 						<div class="flashcard-row padding-top">
 							<button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/src/pages/adj2.ejs
+++ b/src/pages/adj2.ejs
@@ -381,17 +381,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="adj2_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/adj2.ejs
+++ b/src/pages/adj2.ejs
@@ -105,16 +105,16 @@
 						<!-- Nav tabs -->
 						<ul class="nav tabs four-tabs nav-justified" role="tablist">
 							<li role="presentation" class="active">
-								<a href="#god" aria-controls="Good" role="tab" data-toggle="tab">God</a>
+								<a href="#god" aria-controls="god" role="tab" data-toggle="tab">God</a>
 							</li>
 							<li role="presentation">
-								<a href="#halig" aria-controls="Halig" role="tab" data-toggle="tab">Halig</a>
+								<a href="#halig" aria-controls="halig" role="tab" data-toggle="tab">Halig</a>
 							</li>
 							<li role="presentation">
-								<a href="#heah" aria-controls="Heah" role="tab" data-toggle="tab">Heah</a>
+								<a href="#heah" aria-controls="heah" role="tab" data-toggle="tab">Heah</a>
 							</li>
 							<li role="presentation">
-								<a href="#wise" aria-controls="wis" role="tab" data-toggle="tab">Wis</a>
+								<a href="#wis" aria-controls="wis" role="tab" data-toggle="tab">Wis</a>
 							</li>
 						</ul>
 						<!-- Tab panes -->
@@ -260,7 +260,7 @@
 									</tr>
 								</table>
 							</div>
-							<div role="tabpanel" class="text-center tab-pane" id="wise">
+							<div role="tabpanel" class="text-center tab-pane" id="wis">
 								<table class="tabbed-table table-striped inline-block five-col-table table-hide">
 									<tr>
 										<th></th>

--- a/src/pages/adj3.ejs
+++ b/src/pages/adj3.ejs
@@ -446,9 +446,9 @@
 				</div>
 				<form name="form1" autocomplete="OFF">
 					<p>
-						<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-						<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-						<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+						<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+						<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+						<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 						<br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an
 							input
 							selected.</sub>
@@ -456,8 +456,8 @@
 					<div id="question-wrapper" data-question-file="adj3_answers.json">
 					</div>
 					<div class="form-group">
-						<button class="solid-button button" id="submit">Check</button>
-						<button class="solid-button button hidden" id="again">Try Again?</button>
+						<button type="submit" class="solid-button button" id="submit">Check</button>
+						<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 					</div>
 				</form>
 			</section>

--- a/src/pages/adj3.ejs
+++ b/src/pages/adj3.ejs
@@ -160,16 +160,16 @@
 								<!-- Nav tabs -->
 								<ul class="nav tabs four-tabs nav-justified" role="tablist">
 									<li role="presentation" class="active">
-										<a href="#god" aria-controls="Good" role="tab" data-toggle="tab">God</a>
+										<a href="#god" aria-controls="god" role="tab" data-toggle="tab">God</a>
 									</li>
 									<li role="presentation">
-										<a href="#halig" aria-controls="Halig" role="tab" data-toggle="tab">Halig</a>
+										<a href="#halig" aria-controls="halig" role="tab" data-toggle="tab">Halig</a>
 									</li>
 									<li role="presentation">
-										<a href="#heah" aria-controls="Heah" role="tab" data-toggle="tab">Heah</a>
+										<a href="#heah" aria-controls="heah" role="tab" data-toggle="tab">Heah</a>
 									</li>
 									<li role="presentation">
-										<a href="#wilde" aria-controls="wild" role="tab" data-toggle="tab">Wilde</a>
+										<a href="#wilde" aria-controls="wilde" role="tab" data-toggle="tab">Wilde</a>
 									</li>
 								</ul>
 								<!-- Tab panes -->

--- a/src/pages/adj4.ejs
+++ b/src/pages/adj4.ejs
@@ -327,9 +327,9 @@
 				</div>
 				<form name="form1" autocomplete="OFF">
 					<p>
-						<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-						<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-						<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+						<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+						<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+						<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 						<br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an
 							input
 							selected.</sub>
@@ -337,8 +337,8 @@
 					<div id="question-wrapper" data-question-file="adj4_answers.json">
 					</div>
 					<div class="form-group">
-						<button class="solid-button button" id="submit">Check</button>
-						<button class="solid-button button hidden" id="again">Try Again?</button>
+						<button type="submit" class="solid-button button" id="submit">Check</button>
+						<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 					</div>
 				</form>
 			</section>

--- a/src/pages/adj5.ejs
+++ b/src/pages/adj5.ejs
@@ -538,9 +538,9 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">
 				<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
@@ -548,8 +548,8 @@
 			<div id="question-wrapper" data-question-file="adj5_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>
@@ -607,9 +607,9 @@
 						</div>
 
 						<div class="flashcard-row">
-							<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-							<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-							<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+							<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+							<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+							<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 						</div>
 						<div class="flashcard-row padding-top">
 							<button class="solid-button button flashcard-check center-button"

--- a/src/pages/advanced2.ejs
+++ b/src/pages/advanced2.ejs
@@ -270,10 +270,10 @@
                         <!-- Nav tabs -->
                         <ul class="nav tabs five-tabs nav-justified" role="tablist">
                             <li role="presentation" class="active">
-                                <a href="#sculan" aria-controls="shulan" role="tab" data-toggle="tab">Sculan</a>
+                                <a href="#sculan" aria-controls="sculan" role="tab" data-toggle="tab">Sculan</a>
                             </li>
                             <li role="presentation">
-                                <a href="#magan" aria-controls="mayan" role="tab" data-toggle="tab">Magan</a>
+                                <a href="#magan" aria-controls="magan" role="tab" data-toggle="tab">Magan</a>
                             </li>
                             <li role="presentation">
                                 <a href="#motan" aria-controls="motan" role="tab" data-toggle="tab">Motan</a>

--- a/src/pages/advanced2.ejs
+++ b/src/pages/advanced2.ejs
@@ -498,17 +498,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="advanced2_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/advanced3.ejs
+++ b/src/pages/advanced3.ejs
@@ -186,17 +186,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="advanced3_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/advanced4.ejs
+++ b/src/pages/advanced4.ejs
@@ -678,17 +678,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="advanced4_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/advanced6.ejs
+++ b/src/pages/advanced6.ejs
@@ -281,17 +281,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="advanced6_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/cases2.ejs
+++ b/src/pages/cases2.ejs
@@ -353,17 +353,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<small>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</small>
 			</p>
 			<div id="question-wrapper" data-question-file="cases2_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/cases3.ejs
+++ b/src/pages/cases3.ejs
@@ -328,17 +328,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="cases3_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/cases4.ejs
+++ b/src/pages/cases4.ejs
@@ -153,17 +153,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="cases4_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/cases5.ejs
+++ b/src/pages/cases5.ejs
@@ -707,9 +707,9 @@
 				</div>
 				<form name="form1" autocomplete="OFF">
 					<p>
-						<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-						<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-						<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+						<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+						<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+						<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 						<br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an
 							input
 							selected.</sub>
@@ -717,8 +717,8 @@
 					<div id="question-wrapper" data-question-file="cases5_answers.json">
 					</div>
 					<div class="form-group">
-						<button class="solid-button button" id="submit">Check</button>
-						<button class="solid-button button hidden" id="again">Try Again?</button>
+						<button type="submit" class="solid-button button" id="submit">Check</button>
+						<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 					</div>
 				</form>
 			</section>

--- a/src/pages/courseindex.ejs
+++ b/src/pages/courseindex.ejs
@@ -4,277 +4,261 @@
 <main id="mainwrapper" class="container">
 	<section class="row">
 		<div class="col-12">
-			<h1 class="text-center remove-margin">Course Index</h2>
+			<h1 class="text-center remove-margin">Course Index</h1>
 				<p class="text-center"> Click an orange title to begin the module, or choose a specific topic
 					below.</p>
 				<ul class="course-index">
-					<a href="oestart.html">
-						<li class="listtitle">A Quick Note on the Alphabet</li>
-					</a><br>
-					<a href="cases.html">
-						<li class="listtitle">Cases</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="cases2.html">Nominative and Genitive Strong Masculine Nouns</a>
-						</li>
-						<li>
-							<a href="cases3.html">Accusative and Dative Strong Masculine Nouns</a>
-						</li>
-						<li>
-							<a href="cases4.html">Demonstrative Pronouns for Strong Masculine Nouns</a>
-						</li>
-						<li>
-							<a href="cases5.html">Strong Masculine Nouns Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="weakverbs.html">
-						<li class="listtitle">Weak Verbs</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="wv2.html">Brief Intro to Personal Pronouns</a>
-						</li>
-						<li>
-							<a href="wv3.html">Weak Verbs Class I</a>
-						</li>
-						<li>
-							<a href="wv4.html">Weak Verbs Class II</a>
-						</li>
-						<li>
-							<a href="wv5.html">Weak Verbs Class III</a>
-						</li>
-						<li>
-							<a href="wv6.html">Weak Verbs Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="nafnouns.html">
-						<li class="listtitle">Strong Neuter and Feminine Nouns</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="naf2.html">Strong Neuter Nouns</a>
-						</li>
-						<li>
-							<a href="naf3.html">Demonstrative Pronouns for Strong Neuter Nouns</a>
-						</li>
-						<li>
-							<a href="naf4.html">Strong Feminine Nouns</a>
-						</li>
-						<li>
-							<a href="naf5.html">Demonstrative Pronouns for Strong Feminine Nouns</a>
-						</li>
-						<li>
-							<a href="naf6.html">Variant Declensions</a>
-						</li>
-						<li>
-							<a href="naf7.html">Strong Nouns Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="pronouns.html">
-						<li class="listtitle">Pronouns</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="pro2.html">Personal Pronouns</a>
-						</li>
-						<li>
-							<a href="pro3.html">Dual Pronouns</a>
-						</li>
-						<li>
-							<a href="pro4.html">Demonstrative Pronouns</a>
-						</li>
-						<li>
-							<a href="pro5.html">Relative Pronouns</a>
-						</li>
-						<li>
-							<a href="pro6.html">Pronouns Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="irregular.html">
-						<li class="listtitle">Irregular Verbs</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="irgv2.html">Beon and Wesan</a>
-						</li>
-						<li>
-							<a href="irgv3.html">Gan and Don</a>
-						</li>
-						<li>
-							<a href="irgv4.html">Willan</a>
-						</li>
-						<li>
-							<a href="irgv5.html">Irregular Verbs Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="adjectives.html">
-						<li class="listtitle">Adjectives</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="adj2.html">Weak Adjectives</a>
-						</li>
-						<li>
-							<a href="adj3.html">Strong Adjectives</a>
-						</li>
-						<li>
-							<a href="adj4.html">Comparatives and Superlatives</a>
-						</li>
-						<li>
-							<a href="adj5.html">Adjectives Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="weakandminor.html">
-						<li class="listtitle">Weak Nouns and Minor Nouns</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="wam2.html">Weak Nouns</a>
-						</li>
-						<li>
-							<a href="wam3.html">Minor Nouns</a>
-						</li>
-						<li>
-							<a href="wam4.html">i-Mutation</a>
-						</li>
-						<li>
-							<a href="wam5.html">Nouns Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="adverbs.html">
-						<li class="listtitle">Adverbs, Conjunctions, and Prepositions</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="acp2.html">Adverbs</a>
-						</li>
-						<li>
-							<a href="acp3.html">Conjunctions</a>
-						</li>
-						<li>
-							<a href="acp4.html">Prepositions</a>
-						</li>
-						<li>
-							<a href="acp5.html">Adverbs, Conjunctions, and Prepositions Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="moods.html">
-						<li class="listtitle">
-							Moods</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="moods2.html">Imperative</a>
-						</li>
-						<li>
-							<a href="moods3.html">Subjunctive</a>
-						</li>
-						<li>
-							<a href="moods4.html">Moods Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="advanced.html">
-						<li class="listtitle">Additional Verb Forms</li>
-					</a>
-					<ul class="module">
+					<li class="listtitle">
+						<a href="oestart.html">A Quick Note on the Alphabet</a>
+					</li>
+					<li class="listtitle">
+						<a href="cases.html">Cases</a>
+						<ul class="module">
+							<li>
+								<a href="cases2.html">Nominative and Genitive Strong Masculine Nouns</a>
+							</li>
+							<li>
+								<a href="cases3.html">Accusative and Dative Strong Masculine Nouns</a>
+							</li>
+							<li>
+								<a href="cases4.html">Demonstrative Pronouns for Strong Masculine Nouns</a>
+							</li>
+							<li>
+								<a href="cases5.html">Strong Masculine Nouns Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="weakverbs.html">Weak Verbs</a>
+						<ul class="module">
+							<li>
+								<a href="wv2.html">Brief Intro to Personal Pronouns</a>
+							</li>
+							<li>
+								<a href="wv3.html">Weak Verbs Class I</a>
+							</li>
+							<li>
+								<a href="wv4.html">Weak Verbs Class II</a>
+							</li>
+							<li>
+								<a href="wv5.html">Weak Verbs Class III</a>
+							</li>
+							<li>
+								<a href="wv6.html">Weak Verbs Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="nafnouns.html">Strong Neuter and Feminine Nouns</a>
+						<ul class="module">
+							<li>
+								<a href="naf2.html">Strong Neuter Nouns</a>
+							</li>
+							<li>
+								<a href="naf3.html">Demonstrative Pronouns for Strong Neuter Nouns</a>
+							</li>
+							<li>
+								<a href="naf4.html">Strong Feminine Nouns</a>
+							</li>
+							<li>
+								<a href="naf5.html">Demonstrative Pronouns for Strong Feminine Nouns</a>
+							</li>
+							<li>
+								<a href="naf6.html">Variant Declensions</a>
+							</li>
+							<li>
+								<a href="naf7.html">Strong Nouns Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="pronouns.html">Pronouns</a>
+						<ul class="module">
+							<li>
+								<a href="pro2.html">Personal Pronouns</a>
+							</li>
+							<li>
+								<a href="pro3.html">Dual Pronouns</a>
+							</li>
+							<li>
+								<a href="pro4.html">Demonstrative Pronouns</a>
+							</li>
+							<li>
+								<a href="pro5.html">Relative Pronouns</a>
+							</li>
+							<li>
+								<a href="pro6.html">Pronouns Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="irregular.html">Irregular Verbs</a>
+						<ul class="module">
+							<li>
+								<a href="irgv2.html">Beon and Wesan</a>
+							</li>
+							<li>
+								<a href="irgv3.html">Gan and Don</a>
+							</li>
+							<li>
+								<a href="irgv4.html">Willan</a>
+							</li>
+							<li>
+								<a href="irgv5.html">Irregular Verbs Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="adjectives.html">Adjectives</a>
+						<ul class="module">
+							<li>
+								<a href="adj2.html">Weak Adjectives</a>
+							</li>
+							<li>
+								<a href="adj3.html">Strong Adjectives</a>
+							</li>
+							<li>
+								<a href="adj4.html">Comparatives and Superlatives</a>
+							</li>
+							<li>
+								<a href="adj5.html">Adjectives Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="weakandminor.html">Weak Nouns and Minor Nouns</a>		
+						<ul class="module">
+							<li>
+								<a href="wam2.html">Weak Nouns</a>
+							</li>
+							<li>
+								<a href="wam3.html">Minor Nouns</a>
+							</li>
+							<li>
+								<a href="wam4.html">i-Mutation</a>
+							</li>
+							<li>
+								<a href="wam5.html">Nouns Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="adverbs.html">Adverbs, Conjunctions, and Prepositions</a>
+						<ul class="module">
+							<li>
+								<a href="acp2.html">Adverbs</a>
+							</li>
+							<li>
+								<a href="acp3.html">Conjunctions</a>
+							</li>
+							<li>
+								<a href="acp4.html">Prepositions</a>
+							</li>
+							<li>
+								<a href="acp5.html">Adverbs, Conjunctions, and Prepositions Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="moods.html">Moods</a>
 
-						<li>
-							<a href="advanced2.html">Modal Auxiliaries</a>
-						</li>
-						<li>
-							<a href="advanced3.html">Inflected Infinitive</a>
-						</li>
-						<li>
-							<a href="advanced4.html">Participles</a>
-						</li>
-						<li>
-							<a href="advanced5.html">Prefixes</a>
-						</li>
-						<li>
-							<a href="advanced6.html">Additional Verb Forms Overview</a>
-						</li>
-					</ul>
+						<ul class="module">
+							<li>
+								<a href="moods2.html">Imperative</a>
+							</li>
+							<li>
+								<a href="moods3.html">Subjunctive</a>
+							</li>
+							<li>
+								<a href="moods4.html">Moods Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="advanced.html">Additional Verb Forms</a>
+						<ul class="module">
 
-					<br>
-					<a href="strongverbs.html">
-						<li class="listtitle">
-							Strong Verbs
-						</li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="sv1_5.html">Strong Verbs Pronunciation Guide</a>
-						</li>
-						<li>
-							<a href="sv2.html">Strong Verbs Class I</a>
-						</li>
-						<li>
-							<a href="sv3.html">Strong Verbs Class II</a>
-						</li>
-						<li>
-							<a href="sv4.html">Strong Verbs Class III</a>
-						</li>
-						<li>
-							<a href="sv5.html">Strong Verbs Class IV</a>
-						</li>
-						<li>
-							<a href="sv6.html">Strong Verbs Class V</a>
-						</li>
-						<li>
-							<a href="sv7.html">Strong Verbs Class VI</a>
-						</li>
-						<li>
-							<a href="sv8.html">Strong Verbs Class VII</a>
-						</li>
-						<li>
-							<a href="sv9.html">Strong Verb Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="negations.html">
-						<li class="listtitle">
-							Negations </li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="neg2.html">Negated Verbs</a>
-						</li>
-						<li>
-							<a href="neg3.html">Double Negatives</a>
-						</li>
-						<li>
-							<a href="neg4.html">Negations Overview</a>
-						</li>
-					</ul>
-					<br>
-					<a href="syntax.html">
-						<li class="listtitle">
-							Basic Syntax </li>
-					</a>
-					<ul class="module">
-						<li>
-							<a href="syntax2.html">Word Order</a>
-						</li>
-						<li>
-							<a href="syntax3.html">Prose Style</a>
-						</li>
-						<li>
-							<a href="syntax4.html">Poetic Style</a>
-						</li>
-						<li>
-							<a href="syntax5.html">Syntax Overview</a>
-						</li>
-					</ul> 
+							<li>
+								<a href="advanced2.html">Modal Auxiliaries</a>
+							</li>
+							<li>
+								<a href="advanced3.html">Inflected Infinitive</a>
+							</li>
+							<li>
+								<a href="advanced4.html">Participles</a>
+							</li>
+							<li>
+								<a href="advanced5.html">Prefixes</a>
+							</li>
+							<li>
+								<a href="advanced6.html">Additional Verb Forms Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="strongverbs.html">Strong Verbs</a>
+						<ul class="module">
+							<li>
+								<a href="sv1_5.html">Strong Verbs Pronunciation Guide</a>
+							</li>
+							<li>
+								<a href="sv2.html">Strong Verbs Class I</a>
+							</li>
+							<li>
+								<a href="sv3.html">Strong Verbs Class II</a>
+							</li>
+							<li>
+								<a href="sv4.html">Strong Verbs Class III</a>
+							</li>
+							<li>
+								<a href="sv5.html">Strong Verbs Class IV</a>
+							</li>
+							<li>
+								<a href="sv6.html">Strong Verbs Class V</a>
+							</li>
+							<li>
+								<a href="sv7.html">Strong Verbs Class VI</a>
+							</li>
+							<li>
+								<a href="sv8.html">Strong Verbs Class VII</a>
+							</li>
+							<li>
+								<a href="sv9.html">Strong Verb Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="negations.html">Negations</a>
+						<ul class="module">
+							<li>
+								<a href="neg2.html">Negated Verbs</a>
+							</li>
+							<li>
+								<a href="neg3.html">Double Negatives</a>
+							</li>
+							<li>
+								<a href="neg4.html">Negations Overview</a>
+							</li>
+						</ul>
+					</li>
+					<li class="listtitle">
+						<a href="syntax.html">Basic Syntax</a>
+						<ul class="module">
+							<li>
+								<a href="syntax2.html">Word Order</a>
+							</li>
+							<li>
+								<a href="syntax3.html">Prose Style</a>
+							</li>
+							<li>
+								<a href="syntax4.html">Poetic Style</a>
+							</li>
+							<li>
+								<a href="syntax5.html">Syntax Overview</a>
+							</li>
+						</ul> 
+					</li>
+				</ul>
 		</div>
 	</section>
 </main>

--- a/src/pages/irgv2.ejs
+++ b/src/pages/irgv2.ejs
@@ -184,17 +184,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="irgv2_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/irgv3.ejs
+++ b/src/pages/irgv3.ejs
@@ -252,17 +252,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="irgv3_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/irgv4.ejs
+++ b/src/pages/irgv4.ejs
@@ -161,17 +161,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="irgv4_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/irgv5.ejs
+++ b/src/pages/irgv5.ejs
@@ -559,17 +559,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="irgv5_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/license.ejs
+++ b/src/pages/license.ejs
@@ -5,10 +5,10 @@
 	<section class="row">
 		<div class="col-12-sm">
 			<h1 class="remove-margin">Licensing and Copyright Information</h1><br>
-			<p>The project code is licensed under the MIT License. Copyright © 2021 - Victoria Koivisto-Kokko. All code is available publicly on <a class="darkorange-text" target="_blank" href="https://github.com/vkkokko/oldenglishonline">Github</a>.</p>
+			<p>The project code is licensed under the MIT License. Copyright © 2021 - Victoria Koivisto-Kokko. All code is available publicly on <a class="darkorange-text" target="_blank" rel="noopener noreferrer" href="https://github.com/vkkokko/oldenglishonline">Github</a>.</p>
 			<p>The project content (i.e. the textual content, quizzes, graphical organisers) is licensed under Creative Commons Attribution + Share Alike (BY-SA).</p>
 			<p>This website uses Google Analytics to collect anonymised data regarding the site's usage.</p>
-			<p>This website uses material from the Wikipedia article <a class="darkorange-text" target="_blank" href="https://commons.wikimedia.org/wiki/General_phonetics">General Phonetics</a>, which is released under the <a class="darkorange-text" target="_blank" href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-Share-Alike License 3.0</a>.
+			<p>This website uses material from the Wikipedia article <a class="darkorange-text" target="_blank" rel="noopener noreferrer" href="https://commons.wikimedia.org/wiki/General_phonetics">General Phonetics</a>, which is released under the <a class="darkorange-text" target="_blank" rel="noopener noreferrer" href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-Share-Alike License 3.0</a>.
 			</p>
 		</div>
 	</section>

--- a/src/pages/moods2.ejs
+++ b/src/pages/moods2.ejs
@@ -381,17 +381,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="moods2_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/moods3.ejs
+++ b/src/pages/moods3.ejs
@@ -667,17 +667,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="moods3_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/naf2.ejs
+++ b/src/pages/naf2.ejs
@@ -148,16 +148,16 @@
 						<!-- Nav tabs -->
 						<ul class="nav tabs five-tabs nav-justified" role="tablist">
 							<li role="presentation" class="active">
-								<a href="#scip" aria-controls="ship" role="tab" data-toggle="tab">Scip</a>
+								<a href="#scip" aria-controls="scip" role="tab" data-toggle="tab">Scip</a>
 							</li>
 							<li role="presentation">
 								<a href="#word" aria-controls="word" role="tab" data-toggle="tab">Word</a>
 							</li>
 							<li role="presentation">
-								<a href="#bearn" aria-controls="barn" role="tab" data-toggle="tab">Bearn</a>
+								<a href="#bearn" aria-controls="bearn" role="tab" data-toggle="tab">Bearn</a>
 							</li>
 							<li role="presentation">
-								<a href="#wif" aria-controls="wife" role="tab" data-toggle="tab">Wif</a>
+								<a href="#wif" aria-controls="wif" role="tab" data-toggle="tab">Wif</a>
 							</li>
 							<li role="presentation">
 								<a href="#god" aria-controls="god" role="tab" data-toggle="tab">God</a>

--- a/src/pages/naf2.ejs
+++ b/src/pages/naf2.ejs
@@ -496,17 +496,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="naf2_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/naf3.ejs
+++ b/src/pages/naf3.ejs
@@ -149,17 +149,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="naf3_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/naf4.ejs
+++ b/src/pages/naf4.ejs
@@ -156,19 +156,19 @@
 						<!-- Nav tabs -->
 						<ul class="nav tabs five-tabs nav-justified" role="tablist">
 							<li role="presentation" class="active">
-								<a href="#cwen" aria-controls="queen" role="tab" data-toggle="tab">Cwen</a>
+								<a href="#cwen" aria-controls="cwen" role="tab" data-toggle="tab">Cwen</a>
 							</li>
 							<li role="presentation">
-								<a href="#giefu" aria-controls="yifu" role="tab" data-toggle="tab">Giefu</a>
+								<a href="#giefu" aria-controls="giefu" role="tab" data-toggle="tab">Giefu</a>
 							</li>
 							<li role="presentation">
-								<a href="#lufu" aria-controls="love" role="tab" data-toggle="tab">Lufu</a>
+								<a href="#lufu" aria-controls="lufu" role="tab" data-toggle="tab">Lufu</a>
 							</li>
 							<li role="presentation">
-								<a href="#theod" aria-controls="theod" role="tab" data-toggle="tab">Ceaster</a>
+								<a href="#ceaster" aria-controls="ceaster" role="tab" data-toggle="tab">Ceaster</a>
 							</li>
 							<li role="presentation">
-								<a href="#ides" aria-controls="eedes" role="tab" data-toggle="tab">Ides</a>
+								<a href="#ides" aria-controls="ides" role="tab" data-toggle="tab">Ides</a>
 							</li>
 						</ul>
 						<!-- Tab panes -->
@@ -332,7 +332,7 @@
 								</table>
 							</div>
 
-							<div role="tabpanel" class="text-center tab-pane" id="theod">
+							<div role="tabpanel" class="text-center tab-pane" id="ceaster">
 								<table class="tabbed-table table-striped inline-block five-col-table table-hide">
 									<tr>
 										<td colspan="5">

--- a/src/pages/naf4.ejs
+++ b/src/pages/naf4.ejs
@@ -481,17 +481,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="naf4_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/naf5.ejs
+++ b/src/pages/naf5.ejs
@@ -159,17 +159,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="naf5_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/naf6.ejs
+++ b/src/pages/naf6.ejs
@@ -755,17 +755,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="naf6_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/naf7.ejs
+++ b/src/pages/naf7.ejs
@@ -226,15 +226,15 @@
 							<!-- Nav tabs -->
 							<ul class="nav tabs four-tabs nav-justified" role="tablist">
 								<li role="presentation" class="active">
-									<a href="#class1a" aria-controls="class 1" role="tab"
+									<a href="#class1a" aria-controls="class1a" role="tab"
 										data-toggle="tab">Cyning</a>
 								</li>
 								<li role="presentation">
-									<a href="#class1b" aria-controls="class 1b" role="tab"
+									<a href="#class1b" aria-controls="class1b" role="tab"
 										data-toggle="tab">Scip</a>
 								</li>
 								<li role="presentation">
-									<a href="#class1c" aria-controls="class 1c" role="tab"
+									<a href="#class1c" aria-controls="class1c" role="tab"
 										data-toggle="tab">Cwen</a>
 								</li>
 							</ul>

--- a/src/pages/naf7.ejs
+++ b/src/pages/naf7.ejs
@@ -437,17 +437,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="naf7_answers.json" data-additional-questions="naf8_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>
@@ -500,9 +500,9 @@
 						</div>
 						
 						<div class="flashcard-row">
-							<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-							<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-							<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+							<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+							<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+							<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 							</div>
 						<div class="flashcard-row padding-top">
 							<button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/src/pages/neg2.ejs
+++ b/src/pages/neg2.ejs
@@ -334,17 +334,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="neg2_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/pro2.ejs
+++ b/src/pages/pro2.ejs
@@ -286,17 +286,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="pro2_answers.json" data-additional-questions="pro2_5_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/pro3.ejs
+++ b/src/pages/pro3.ejs
@@ -100,17 +100,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="pro3_answers.json" data-additional-questions="pro3_5_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/pro4.ejs
+++ b/src/pages/pro4.ejs
@@ -365,17 +365,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="pro4_answers.json" data-additional-questions="pro4_5_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/pro6.ejs
+++ b/src/pages/pro6.ejs
@@ -465,17 +465,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="pro6_answers.json" data-table-file="table_test.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/sv2.ejs
+++ b/src/pages/sv2.ejs
@@ -517,17 +517,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="sv2_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/sv3.ejs
+++ b/src/pages/sv3.ejs
@@ -159,7 +159,7 @@
                                 <a href="#beodan" aria-controls="beodan" role="tab" data-toggle="tab">Beodan</a>
                             </li>
                             <li role="presentation">
-                                <a href="#leogan" aria-controls="leoyan" role="tab" data-toggle="tab">Leogan</a>
+                                <a href="#leogan" aria-controls="leogan" role="tab" data-toggle="tab">Leogan</a>
                             </li>
                             <li role="presentation">
                                 <a href="#brucan" aria-controls="brucan" role="tab" data-toggle="tab">Brucan</a>

--- a/src/pages/sv3.ejs
+++ b/src/pages/sv3.ejs
@@ -465,17 +465,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="sv3_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/sv4.ejs
+++ b/src/pages/sv4.ejs
@@ -508,17 +508,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="sv4_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/sv4.ejs
+++ b/src/pages/sv4.ejs
@@ -207,7 +207,7 @@
                                 <a href="#weorpan" aria-controls="weorpan" role="tab" data-toggle="tab">Weorpan</a>
                             </li>
                             <li role="presentation">
-                                <a href="#gieldan" aria-controls="yieldan" role="tab" data-toggle="tab">Gieldan</a>
+                                <a href="#gieldan" aria-controls="gieldan" role="tab" data-toggle="tab">Gieldan</a>
                             </li>
                         </ul>
                         <!-- Tab panes -->

--- a/src/pages/sv5.ejs
+++ b/src/pages/sv5.ejs
@@ -400,17 +400,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="sv5_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/sv6.ejs
+++ b/src/pages/sv6.ejs
@@ -461,17 +461,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="sv6_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/sv7.ejs
+++ b/src/pages/sv7.ejs
@@ -158,10 +158,10 @@
                         <!-- Nav tabs -->
                         <ul class="nav tabs five-tabs nav-justified" role="tablist">
                             <li role="presentation" class="active">
-                                <a href="#wascan" aria-controls="washan" role="tab" data-toggle="tab">Wascan</a>
+                                <a href="#wascan" aria-controls="wascan" role="tab" data-toggle="tab">Wascan</a>
                             </li>
                             <li role="presentation">
-                                <a href="#dragan" aria-controls="drayan" role="tab" data-toggle="tab">Dragan</a>
+                                <a href="#dragan" aria-controls="dragan" role="tab" data-toggle="tab">Dragan</a>
                             </li>
                             <li role="presentation">
                                 <a href="#slean" aria-controls="slean" role="tab" data-toggle="tab">Slean</a>

--- a/src/pages/sv7.ejs
+++ b/src/pages/sv7.ejs
@@ -494,17 +494,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="sv7_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/sv8.ejs
+++ b/src/pages/sv8.ejs
@@ -165,7 +165,7 @@
                                 <a href="#hatan" aria-controls="hatan" role="tab" data-toggle="tab">Hatan</a>
                             </li>
                             <li role="presentation">
-                                <a href="#raedan" aria-controls="raedan" role="tab" data-toggle="tab">Blawan</a>
+                                <a href="#blawan" aria-controls="blawan" role="tab" data-toggle="tab">Blawan</a>
                             </li>
                             <li role="presentation">
                                 <a href="#hleapan" aria-controls="hleapan" role="tab" data-toggle="tab">Hleapan</a>

--- a/src/pages/sv8.ejs
+++ b/src/pages/sv8.ejs
@@ -474,17 +474,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="sv8_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/sv9.ejs
+++ b/src/pages/sv9.ejs
@@ -232,25 +232,25 @@
                         <!-- Nav tabs -->
                         <ul class="nav tabs five-tabs nav-justified" role="tablist">
                             <li role="presentation" class="active">
-                                <a href="#i" aria-controls="class one" role="tab" data-toggle="tab">I</a>
+                                <a href="#i" aria-controls="i" role="tab" data-toggle="tab">I</a>
                             </li>
                             <li role="presentation">
-                                <a href="#ii" aria-controls="class two" role="tab" data-toggle="tab">II</a>
+                                <a href="#ii" aria-controls="ii" role="tab" data-toggle="tab">II</a>
                             </li>
                             <li role="presentation">
-                                <a href="#iii" aria-controls="class three" role="tab" data-toggle="tab">III</a>
+                                <a href="#iii" aria-controls="iii" role="tab" data-toggle="tab">III</a>
                             </li>
                             <li role="presentation">
-                                <a href="#iv" aria-controls="class four" role="tab" data-toggle="tab">IV</a>
+                                <a href="#iv" aria-controls="iv" role="tab" data-toggle="tab">IV</a>
                             </li>
                             <li role="presentation">
-                                <a href="#v" aria-controls="class five" role="tab" data-toggle="tab">V</a>
+                                <a href="#v" aria-controls="v" role="tab" data-toggle="tab">V</a>
                             </li>
                             <li role="presentation">
-                                <a href="#vi" aria-controls="class six" role="tab" data-toggle="tab">VI</a>
+                                <a href="#vi" aria-controls="vi" role="tab" data-toggle="tab">VI</a>
                             </li>
                             <li role="presentation">
-                                <a href="#vii" aria-controls="class seven" role="tab" data-toggle="tab">VII</a>
+                                <a href="#vii" aria-controls="vii" role="tab" data-toggle="tab">VII</a>
                             </li>
                         </ul>
                         <!-- Tab panes -->

--- a/src/pages/sv9.ejs
+++ b/src/pages/sv9.ejs
@@ -629,17 +629,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="sv9_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>
@@ -689,9 +689,9 @@
 						</div>
 						
 						<div class="flashcard-row">
-							<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-							<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-							<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+							<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+							<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+							<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 							</div>
 						<div class="flashcard-row small-padding-top">
 							<button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/src/pages/test.ejs
+++ b/src/pages/test.ejs
@@ -19,9 +19,9 @@
 			</div>
 		<form name="test-form" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>

--- a/src/pages/wam2.ejs
+++ b/src/pages/wam2.ejs
@@ -280,9 +280,9 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs">
                 <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
@@ -290,8 +290,8 @@
             <div id="question-wrapper" data-question-file="wam2_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/wam2.ejs
+++ b/src/pages/wam2.ejs
@@ -77,10 +77,10 @@
                                 <a href="#hunta" aria-controls="hunta" role="tab" data-toggle="tab">Hunta</a>
                             </li>
                             <li role="presentation">
-                                <a href="#eage" aria-controls="eye" role="tab" data-toggle="tab">Eage</a>
+                                <a href="#eage" aria-controls="eage" role="tab" data-toggle="tab">Eage</a>
                             </li>
                             <li role="presentation">
-                                <a href="#tunge" aria-controls="tongue" role="tab" data-toggle="tab">Tunge</a>
+                                <a href="#tunge" aria-controls="tunge" role="tab" data-toggle="tab">Tunge</a>
                             </li>
                         </ul>
                         <!-- Tab panes -->

--- a/src/pages/wam3.ejs
+++ b/src/pages/wam3.ejs
@@ -248,7 +248,7 @@
                                 <a href="#cealf" aria-controls="cealf" role="tab" data-toggle="tab">Cealf</a>
                             </li>
                             <li role="presentation">
-                                <a href="#aeg" aria-controls="ay" role="tab" data-toggle="tab">&AElig;g</a>
+                                <a href="#aeg" aria-controls="aeg" role="tab" data-toggle="tab">&AElig;g</a>
                             </li>
                             <li role="presentation">
                                 <a href="#lamb" aria-controls="lamb" role="tab" data-toggle="tab">Lamb</a>
@@ -551,7 +551,7 @@
                         <!-- Nav tabs -->
                         <ul class="nav tabs five-tabs nav-justified" role="tablist">
                             <li role="presentation" class="active">
-                                <a href="#faeder" aria-controls="fader" role="tab" data-toggle="tab">Fæder</a>
+                                <a href="#faeder" aria-controls="faeder" role="tab" data-toggle="tab">Fæder</a>
                             </li>
                             <li role="presentation">
                                 <a href="#modor" aria-controls="modor" role="tab" data-toggle="tab">Modor</a>

--- a/src/pages/wam3.ejs
+++ b/src/pages/wam3.ejs
@@ -877,9 +877,9 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs">
                 <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
@@ -887,8 +887,8 @@
             <div id="question-wrapper" data-question-file="wam3_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/wam4.ejs
+++ b/src/pages/wam4.ejs
@@ -575,9 +575,9 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs">
                 <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
@@ -585,8 +585,8 @@
             <div id="question-wrapper" data-question-file="wam4_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>

--- a/src/pages/wam4.ejs
+++ b/src/pages/wam4.ejs
@@ -423,7 +423,7 @@
                         <!-- Nav tabs -->
                         <ul class="nav tabs three-tabs nav-justified" role="tablist">
                             <li role="presentation" class="active">
-                                <a href="#mann" aria-controls="man" role="tab" data-toggle="tab">Mann</a>
+                                <a href="#mann" aria-controls="mann" role="tab" data-toggle="tab">Mann</a>
                             </li>
                             <li role="presentation">
                                 <a href="#boc" aria-controls="boc" role="tab" data-toggle="tab">Boc</a>

--- a/src/pages/wam5.ejs
+++ b/src/pages/wam5.ejs
@@ -843,17 +843,17 @@
         </div>
         <form name="form1" autocomplete="OFF">
             <p>
-                <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                 <br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
                     selected.</sub>
             </p>
             <div id="question-wrapper" data-question-file="wam5_answers.json" data-additional-questions="wam6_answers.json">
             </div>
             <div class="form-group">
-                <button class="solid-button button" id="submit">Check</button>
-                <button class="solid-button button hidden" id="again">Try Again?</button>
+                <button type="submit" class="solid-button button" id="submit">Check</button>
+                <button type="button" class="solid-button button hidden" id="again">Try Again?</button>
             </div>
         </form>
     </section>
@@ -905,9 +905,9 @@
                         </div>
 
                         <div class="flashcard-row">
-                            <button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-                            <button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-                            <button class="light-button button special-character" data-char="&eth;">&eth;</button>
+                            <button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+                            <button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+                            <button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
                         </div>
                         <div class="flashcard-row padding-top">
                             <button class="solid-button button flashcard-check center-button"

--- a/src/pages/wv2.ejs
+++ b/src/pages/wv2.ejs
@@ -177,17 +177,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="wv2_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/wv3.ejs
+++ b/src/pages/wv3.ejs
@@ -641,17 +641,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="wv3_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/wv4.ejs
+++ b/src/pages/wv4.ejs
@@ -559,17 +559,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="wv4_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>

--- a/src/pages/wv5.ejs
+++ b/src/pages/wv5.ejs
@@ -408,9 +408,9 @@
 				</div>
 				<form name="form1" autocomplete="OFF">
 					<p>
-						<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-						<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-						<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+						<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+						<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+						<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 						<br class="visible-xs"> <sub>Use these buttons to insert thorn, ash and eth when you have an
 							input
 							selected.</sub>
@@ -418,8 +418,8 @@
 					<div id="question-wrapper" data-question-file="wv5_answers.json">
 					</div>
 					<div class="form-group">
-						<button class="solid-button button" id="submit">Check</button>
-						<button class="solid-button button hidden" id="again">Try Again?</button>
+						<button type="submit" class="solid-button button" id="submit">Check</button>
+						<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 					</div>
 				</form>
 			</section>

--- a/src/pages/wv6.ejs
+++ b/src/pages/wv6.ejs
@@ -954,17 +954,17 @@
 		</div>
 		<form name="form1" autocomplete="OFF">
 			<p>
-				<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-				<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-				<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+				<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+				<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+				<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 				<br class="visible-xs">			<sub>Use these buttons to insert thorn, ash and eth when you have an input
 					selected.</sub>
 			</p>
 			<div id="question-wrapper" data-question-file="wv6_answers.json">
 			</div>
 			<div class="form-group">
-				<button class="solid-button button" id="submit">Check</button>
-				<button class="solid-button button hidden" id="again">Try Again?</button>
+				<button type="submit" class="solid-button button" id="submit">Check</button>
+				<button type="button" class="solid-button button hidden" id="again">Try Again?</button>
 			</div>
 		</form>
 	</section>
@@ -1015,9 +1015,9 @@
 						</div>
 						
 						<div class="flashcard-row">
-							<button class="light-button button special-character" data-char="&thorn;">&thorn;</button>
-							<button class="light-button button special-character" data-char="&aelig;">&aelig;</button>
-							<button class="light-button button special-character" data-char="&eth;">&eth;</button>
+							<button type="button" class="light-button button special-character" data-char="&thorn;">&thorn;</button>
+							<button type="button" class="light-button button special-character" data-char="&aelig;">&aelig;</button>
+							<button type="button" class="light-button button special-character" data-char="&eth;">&eth;</button>
 							</div>
 						<div class="flashcard-row small-padding-top">
 							<button class="solid-button button flashcard-check center-button" aria-label="Check">Check</button>

--- a/src/pages/wv6.ejs
+++ b/src/pages/wv6.ejs
@@ -622,16 +622,16 @@
 						<!-- Nav tabs -->
 						<ul class="nav tabs four-tabs nav-justified" role="tablist">
 							<li role="presentation" class="active">
-								<a href="#class1a" aria-controls="class 1" role="tab" data-toggle="tab">Class I(a)</a>
+								<a href="#class1a" aria-controls="class1a" role="tab" data-toggle="tab">Class I(a)</a>
 							</li>
 							<li role="presentation">
-								<a href="#class1b" aria-controls="class 1b" role="tab" data-toggle="tab">Class I(b)</a>
+								<a href="#class1b" aria-controls="class1b" role="tab" data-toggle="tab">Class I(b)</a>
 							</li>
 							<li role="presentation">
-								<a href="#class1c" aria-controls="class 1c" role="tab" data-toggle="tab">Class I(c)</a>
+								<a href="#class1c" aria-controls="class1c" role="tab" data-toggle="tab">Class I(c)</a>
 							</li>
 							<li role="presentation">
-								<a href="#class2a" aria-controls="class 2" role="tab" data-toggle="tab">Class II</a>
+								<a href="#class2a" aria-controls="class2a" role="tab" data-toggle="tab">Class II</a>
 							</li>
 						</ul>
 						<!-- Tab panes -->

--- a/src/partials/head.ejs
+++ b/src/partials/head.ejs
@@ -1,7 +1,6 @@
-<meta name="viewport" content="width=device-width, initial-scale=1">
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="language" content="<%= locals.site.languageLong -%>">
-<meta http-equiv="content-type" content="text/html">
 <meta name="author" content="Victoria Koivisto-Kokko">
 <meta name="designer" content="Victoria Koivisto-Kokko">
 <meta name="publisher" content="Victoria Koivisto-Kokko">

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -164,8 +164,8 @@
 			loadQuestionsInto($container, filename);
 
 			$('small').replaceWith('<small>In the textboxes below, fill out the fully declined version of the word in brackets.</small>');
-			$('#table-submit').replaceWith('<button class="solid-button button" id="submit">Check</button>');
-			$('#table-try-again').replaceWith('<button class="solid-button button hidden" id="again">Try Again?</button>');
+			$('#table-submit').replaceWith('<button type="submit" class="solid-button button" id="submit">Check</button>');
+			$('#table-try-again').replaceWith('<button type="button" class="solid-button button hidden" id="again">Try Again?</button>');
 		});
 
 	});

--- a/src/scripts/scraps.js
+++ b/src/scripts/scraps.js
@@ -11,8 +11,8 @@
 //     loadQuestionsInto($container, filename);
 
 //     $('small').replaceWith('<small>In the textboxes below, fill out the fully declined version of the word in brackets.</small>');
-//     $('#table-submit').replaceWith('<button class="solid-button button" id="submit">Check</button>');
-//     $('#table-try-again').replaceWith('<button class="solid-button button hidden" id="again">Try Again?</button>');
+//     $('#table-submit').replaceWith('<button type="submit" class="solid-button button" id="submit">Check</button>');
+//     $('#table-try-again').replaceWith('<button type="button" class="solid-button button hidden" id="again">Try Again?</button>');
 // });
 
 // //This is the code which replaces the fill-in-the-blank with the table quiz

--- a/src/styles/oeccss.css
+++ b/src/styles/oeccss.css
@@ -1075,10 +1075,16 @@ table th {
 
 li.listtitle {
 	list-style-type: none;
+	margin-bottom: 24px;
+}
+
+li.listtitle > a {
 	color: rgb(200, 100, 50);
+	font-family: Georgia, Times, "Times New Roman", serif;
 	font-size: 24px;
 	font-weight: bold;
 	text-decoration: underline;
+	display: block;
 }
 
 li.inactive {
@@ -1095,8 +1101,15 @@ ul.module li {
 	padding-top: 5px;
 }
 
-ul.module a {
+ul.module a,
+ul.module a >:visited {
 	color: black;
+	text-decoration: none;
+}
+
+ul.module a:hover,
+ul.module a:focus {
+	text-decoration: underline;
 }
 
 .user-input {

--- a/src/styles/oeccss.css
+++ b/src/styles/oeccss.css
@@ -1063,8 +1063,13 @@ table th {
 .bc-icons-2 .breadcrumb-item + .breadcrumb-item::before {
 	content: none;
 }
+
 .bc-icons-2 .breadcrumb-item.active {
 	color: rgb(200, 100, 50);
+}
+
+.bc-icons-2 .breadcrumb .fa-angle-double-right {
+  	margin: 0 4px;
 }
 
 /* Module index*/


### PR DESCRIPTION
Summary: This PR updates EJS templates and regenerates docs so the deployed site reflects accessibility/template fixes.

Changes:

- ARIA fixes for Bootstrap tab navigation (aria-controls values + mismatches)
- Explicit type attributes on form buttons to prevent unintended submits
- rel="noopener" for external links opened in new tabs
- Minor breadcrumb spacing
- Course index list structure correction
- Head template cleanup (meta ordering / remove legacy content-type meta)
- Regenerated docs/ output (final commit)

The only intentional visual changes are:
- Slightly increased spacing in the breadcrumb trail for readability
- Minor spacing adjustment on the Course Index after replacing <br> elements with CSS spacing

All other changes are structural, accessibility-related, or template hygiene updates.